### PR TITLE
fix: SimpleMiddleware slash function

### DIFF
--- a/middleware/src/SimpleMiddleware.sol
+++ b/middleware/src/SimpleMiddleware.sol
@@ -293,7 +293,7 @@ contract SimpleMiddleware is SimpleKeyRegistry32, Ownable {
 
         // simple pro-rata slasher
         for (uint256 i; i < vaults.length(); ++i) {
-            (address vault, uint48 enabledTime, uint48 disabledTime) = operators.atWithTimes(i);
+            (address vault, uint48 enabledTime, uint48 disabledTime) = vaults.atWithTimes(i);
 
             // just skip the vault if it was enabled after the target epoch or not enabled
             if (!_wasActiveAt(enabledTime, disabledTime, epochStartTs)) {


### PR DESCRIPTION
* [`middleware/src/SimpleMiddleware.sol`](diffhunk://#diff-bdc2cc8c5c1ee120cfdfd111c2178d4de7089dabafbe52584fd4a967d66c8bb4L296-R296): Changed the variable `operators` to `vaults` in the loop to correctly access the vault data.